### PR TITLE
Add support for Braintree::AddOn.all

### DIFF
--- a/lib/fake_braintree/sinatra_app.rb
+++ b/lib/fake_braintree/sinatra_app.rb
@@ -193,5 +193,10 @@ module FakeBraintree
       redirect = FakeBraintree.registry.redirects[params[:id]]
       redirect.confirm
     end
+
+    # Braintree::AddOn.all
+    get '/merchants/:merchant_id/add_ons' do
+      gzipped_response(200, [].to_xml(root: 'add_ons'))
+    end
   end
 end

--- a/spec/fake_braintree/add_on_spec.rb
+++ b/spec/fake_braintree/add_on_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe "Braintree::AddOn.all" do
+  it "returns no addons" do
+    add_on_response = Braintree::AddOn.all
+
+    expect(add_on_response).to be_empty
+  end
+end


### PR DESCRIPTION
We need the ability to grab add-ons when using FakeBraintree, and in
this instance we simply return no add-ons